### PR TITLE
-Ofast compiling fixes and important fixup for 4.4.220

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -901,8 +901,8 @@ include scripts/Makefile.extrawarn
 include scripts/Makefile.ubsan
 
 # Add Device Specific Optimization
-KBUILD_CFLAGS += -march=armv8-a+crypto -march=armv8-a+crc -mcpu=cortex-a53 -O2
-KBUILD_CPPFLAGS += -march=armv8-a+crypto -march=armv8-a+crc -mcpu=cortex-a53 -O2
+KBUILD_CFLAGS += -march=armv8-a+crypto -march=armv8-a+crc -mcpu=cortex-a53 -Ofast
+KBUILD_CPPFLAGS += -march=armv8-a+crypto -march=armv8-a+crc -mcpu=cortex-a53 -Ofast
 
 # Add any arch overrides and user supplied CPPFLAGS, AFLAGS and CFLAGS as the
 # last assignments

--- a/drivers/hisi/isp/Makefile
+++ b/drivers/hisi/isp/Makefile
@@ -1,10 +1,13 @@
 ifneq ($(TARGET_BUILD_VARIANT),user)
 EXTRA_CFLAGS += -DDEBUG_HISI_ISP
+ccflags-y := -O2
 endif
 
 obj-y    += hisi_atfisp.o hisi_fstcma.o hisi_isp_rproc.o rpmsg_hisi.o rpmsg_sensor.o
+ccflags-y := -O2
 ifeq ($(CONFIG_HISI_HISTAR_ISP), y)
 EXTRA_CFLAGS += -Idrivers/hisi/tzdriver \
                 -Idrivers/hisi/load_image \
                 -I$(src)/../../../../../../../external/efipartition
+ccflags-y := -O2
 endif

--- a/drivers/usb/gadget/composite.c
+++ b/drivers/usb/gadget/composite.c
@@ -822,11 +822,6 @@ static int set_config(struct usb_composite_dev *cdev,
 	/* when we return, be sure our power usage is valid */
 	power = c->MaxPower ? c->MaxPower : CONFIG_USB_GADGET_VBUS_DRAW;
 done:
-	if (power <= USB_SELF_POWER_VBUS_MAX_DRAW)
-		usb_gadget_set_selfpowered(gadget);
-	else
-		usb_gadget_clear_selfpowered(gadget);
-
 	usb_gadget_vbus_draw(gadget, power);
 	if (result >= 0 && cdev->delayed_status)
 		result = USB_GADGET_DELAYED_STATUS;
@@ -2257,7 +2252,6 @@ void composite_suspend(struct usb_gadget *gadget)
 
 	cdev->suspended = 1;
 
-	usb_gadget_set_selfpowered(gadget);
 	usb_gadget_vbus_draw(gadget, 2);
 }
 
@@ -2280,9 +2274,6 @@ void composite_resume(struct usb_gadget *gadget)
 		}
 
 		maxpower = cdev->config->MaxPower;
-
-		if (maxpower > USB_SELF_POWER_VBUS_MAX_DRAW)
-			usb_gadget_clear_selfpowered(gadget);
 
 		usb_gadget_vbus_draw(gadget, maxpower ?
 			maxpower : CONFIG_USB_GADGET_VBUS_DRAW);


### PR DESCRIPTION
I don't know why but this fix wasn't included in previous pull request. it fixes the device becoming unresponsive if you plug a usb in appeared after 220 update